### PR TITLE
Enable admin control for devices and services

### DIFF
--- a/src/actions/dashboard/addDeviceAction.ts
+++ b/src/actions/dashboard/addDeviceAction.ts
@@ -1,0 +1,19 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Device from "@/models/Device";
+import { revalidateTag } from "next/cache";
+
+const addDeviceAction = async (name: string) => {
+  try {
+    await connectToDatabase();
+    const device = new Device({ name });
+    await device.save();
+    revalidateTag('/admin/devices');
+    return { status: "success", message: "Device created" };
+  } catch (error) {
+    console.error("Error adding device:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default addDeviceAction;

--- a/src/actions/dashboard/addServiceAction.ts
+++ b/src/actions/dashboard/addServiceAction.ts
@@ -1,0 +1,19 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Service from "@/models/Service";
+import { revalidateTag } from "next/cache";
+
+const addServiceAction = async (device: string, name: string, cost: number) => {
+  try {
+    await connectToDatabase();
+    const service = new Service({ device, name, cost });
+    await service.save();
+    revalidateTag('/admin/services');
+    return { status: "success", message: "Service created" };
+  } catch (error) {
+    console.error("Error adding service:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default addServiceAction;

--- a/src/actions/dashboard/deleteDeviceAction.ts
+++ b/src/actions/dashboard/deleteDeviceAction.ts
@@ -1,0 +1,18 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Device from "@/models/Device";
+import { revalidateTag } from "next/cache";
+
+const deleteDeviceAction = async (id: string) => {
+  try {
+    await connectToDatabase();
+    await Device.findByIdAndDelete(id);
+    revalidateTag('/admin/devices');
+    return { status: "success", message: "Device deleted" };
+  } catch (error) {
+    console.error("Error deleting device:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default deleteDeviceAction;

--- a/src/actions/dashboard/deleteServiceAction.ts
+++ b/src/actions/dashboard/deleteServiceAction.ts
@@ -1,0 +1,18 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Service from "@/models/Service";
+import { revalidateTag } from "next/cache";
+
+const deleteServiceAction = async (id: string) => {
+  try {
+    await connectToDatabase();
+    await Service.findByIdAndDelete(id);
+    revalidateTag('/admin/services');
+    return { status: "success", message: "Service deleted" };
+  } catch (error) {
+    console.error("Error deleting service:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default deleteServiceAction;

--- a/src/actions/dashboard/getDevicesAction.ts
+++ b/src/actions/dashboard/getDevicesAction.ts
@@ -1,0 +1,19 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Device from "@/models/Device";
+import { serializeData } from "@/lib/utils";
+
+const getDevicesAction = async (page: number = 1, limit: number = 5) => {
+  try {
+    const skip = (page - 1) * limit;
+    await connectToDatabase();
+    const devices = await Device.find().skip(skip).limit(limit).lean();
+    const totalItemsLength = await Device.countDocuments();
+    return { status: "success", items: serializeData(devices), totalItemsLength };
+  } catch (error) {
+    console.error("Error fetching devices:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default getDevicesAction;

--- a/src/actions/dashboard/getServicesAction.ts
+++ b/src/actions/dashboard/getServicesAction.ts
@@ -1,0 +1,19 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import Service from "@/models/Service";
+import { serializeData } from "@/lib/utils";
+
+const getServicesAction = async (page: number = 1, limit: number = 5) => {
+  try {
+    const skip = (page - 1) * limit;
+    await connectToDatabase();
+    const services = await Service.find().populate('device').skip(skip).limit(limit).lean();
+    const totalItemsLength = await Service.countDocuments();
+    return { status: "success", items: serializeData(services), totalItemsLength };
+  } catch (error) {
+    console.error("Error fetching services:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default getServicesAction;

--- a/src/app/admin/devices/page.tsx
+++ b/src/app/admin/devices/page.tsx
@@ -1,0 +1,40 @@
+import { SearchParams } from "@/types";
+import SelectShowing from "@/components/dashboard/SelectShowing";
+import DashboardContainer from "@/components/dashboard/DashboardContainer";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import DashboardContent from "@/components/dashboard/DashboardContent";
+import DashboardTitle from "@/components/dashboard/DashboardTitle";
+import DeviceTable from "@/components/dashboard/DeviceTable";
+import { AddDeviceDialog } from "@/components/dashboard/dialogs/AddDeviceDialog";
+import getDevicesAction from "@/actions/dashboard/getDevicesAction";
+import deleteDeviceAction from "@/actions/dashboard/deleteDeviceAction";
+
+const DevicesPage = async ({ searchParams }: SearchParams) => {
+  const { page = 1, perPage = 5 } = await searchParams;
+  const { items, totalItemsLength } = await getDevicesAction(
+    Number(page),
+    Number(perPage),
+  );
+  return (
+    <DashboardContainer className="w-full min-h-screen py-12 px-10 overflow-y-auto">
+      <DashboardHeader className="flex justify-between">
+        <DashboardTitle>Devices</DashboardTitle>
+        <div className="flex gap-4">
+          <SelectShowing />
+          <AddDeviceDialog />
+        </div>
+      </DashboardHeader>
+      <DashboardContent className="bg-background shadow p-6 rounded-lg">
+        <DeviceTable
+          page={page}
+          per_page={perPage}
+          deleteAction={deleteDeviceAction}
+          items={items}
+          totalItemsLength={totalItemsLength}
+        />
+      </DashboardContent>
+    </DashboardContainer>
+  );
+};
+
+export default DevicesPage;

--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -1,0 +1,40 @@
+import { SearchParams } from "@/types";
+import SelectShowing from "@/components/dashboard/SelectShowing";
+import DashboardContainer from "@/components/dashboard/DashboardContainer";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import DashboardContent from "@/components/dashboard/DashboardContent";
+import DashboardTitle from "@/components/dashboard/DashboardTitle";
+import ServiceTable from "@/components/dashboard/ServiceTable";
+import { AddServiceDialog } from "@/components/dashboard/dialogs/AddServiceDialog";
+import getServicesAction from "@/actions/dashboard/getServicesAction";
+import deleteServiceAction from "@/actions/dashboard/deleteServiceAction";
+
+const ServicesPage = async ({ searchParams }: SearchParams) => {
+  const { page = 1, perPage = 5 } = await searchParams;
+  const { items, totalItemsLength } = await getServicesAction(
+    Number(page),
+    Number(perPage),
+  );
+  return (
+    <DashboardContainer className="w-full min-h-screen py-12 px-10 overflow-y-auto">
+      <DashboardHeader className="flex justify-between">
+        <DashboardTitle>Services</DashboardTitle>
+        <div className="flex gap-4">
+          <SelectShowing />
+          <AddServiceDialog />
+        </div>
+      </DashboardHeader>
+      <DashboardContent className="bg-background shadow p-6 rounded-lg">
+        <ServiceTable
+          page={page}
+          per_page={perPage}
+          deleteAction={deleteServiceAction}
+          items={items}
+          totalItemsLength={totalItemsLength}
+        />
+      </DashboardContent>
+    </DashboardContainer>
+  );
+};
+
+export default ServicesPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import AppProvider from "@/providers/AppProvider";
 import "./globals.css";
 import Providers from "./providers"
 import { getSession } from "@/auth"
+import { ensureDefaultAdmin } from "@/lib/initAdmin"
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -27,6 +28,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  await ensureDefaultAdmin()
   const session = await getSession()
 
   return (

--- a/src/components/dashboard/DeviceTable.tsx
+++ b/src/components/dashboard/DeviceTable.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { IDevice } from "@/models/Device";
+import DeleteButton from "@/components/dashboard/buttons/DeleteButton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import PaginationControls from "./PaginationControls";
+
+export default function DeviceTable({
+  items,
+  totalItemsLength,
+  page,
+  per_page,
+  deleteAction,
+}: {
+  items: IDevice[];
+  totalItemsLength: number;
+  page: string | string[];
+  per_page: string | string[];
+  deleteAction: (id: string) => void;
+}) {
+  const start = (Number(page) - 1) * Number(per_page);
+  const totalPages = Math.ceil(totalItemsLength / Number(per_page));
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="min-w-[200px]">Name</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items?.map(({ _id, name }) => (
+          <TableRow key={_id?.toString() as string}>
+            <TableCell>{name}</TableCell>
+            <TableCell className="text-right">
+              <DeleteButton action={deleteAction} id={_id as string} />
+            </TableCell>
+          </TableRow>
+        ))}
+        <TableRow>
+          <TableCell
+            className="bg-background text-muted-foreground pb-0"
+            colSpan={1}
+          >
+            Total Items: {totalItemsLength}
+          </TableCell>
+          <TableCell className="bg-background pb-0" colSpan={1}>
+            <PaginationControls
+              hasNextPage={Number(page) < totalPages}
+              hasPrevPage={start > 0}
+              totalItemsLength={totalItemsLength}
+            />
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/dashboard/ServiceTable.tsx
+++ b/src/components/dashboard/ServiceTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { IService } from "@/models/Service";
+import DeleteButton from "@/components/dashboard/buttons/DeleteButton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import PaginationControls from "./PaginationControls";
+
+export default function ServiceTable({
+  items,
+  totalItemsLength,
+  page,
+  per_page,
+  deleteAction,
+}: {
+  items: IService[];
+  totalItemsLength: number;
+  page: string | string[];
+  per_page: string | string[];
+  deleteAction: (id: string) => void;
+}) {
+  const start = (Number(page) - 1) * Number(per_page);
+  const totalPages = Math.ceil(totalItemsLength / Number(per_page));
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="min-w-[150px]">Device</TableHead>
+          <TableHead className="min-w-[200px]">Name</TableHead>
+          <TableHead className="min-w-[100px]">Cost</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items?.map(({ _id, device, name, cost }) => (
+          <TableRow key={_id?.toString() as string}>
+            <TableCell>{typeof device === 'string' ? device : (device as any)?.name}</TableCell>
+            <TableCell>{name}</TableCell>
+            <TableCell>${cost}</TableCell>
+            <TableCell className="text-right">
+              <DeleteButton action={deleteAction} id={_id as string} />
+            </TableCell>
+          </TableRow>
+        ))}
+        <TableRow>
+          <TableCell className="bg-background text-muted-foreground pb-0" colSpan={3}>
+            Total Items: {totalItemsLength}
+          </TableCell>
+          <TableCell className="bg-background pb-0" colSpan={1}>
+            <PaginationControls
+              hasNextPage={Number(page) < totalPages}
+              hasPrevPage={start > 0}
+              totalItemsLength={totalItemsLength}
+            />
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -26,6 +26,16 @@ const adminLinks = [
     label: "Users",
     icon: <FaUsers />,
   },
+  {
+    href: "/admin/devices",
+    label: "Devices",
+    icon: <FaTasks />,
+  },
+  {
+    href: "/admin/services",
+    label: "Services",
+    icon: <FaTasks />,
+  },
 ];
 
 const workerLinks = [

--- a/src/components/dashboard/dialogs/AddDeviceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddDeviceDialog.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useState } from "react";
+import useCustomToast from "@/hooks/useCustomToast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import InputFormField from "@/components/InputFormField";
+import addDeviceAction from "@/actions/dashboard/addDeviceAction";
+
+const DeviceSchema = z.object({
+  name: z.string().min(1, { message: "Name is required" }).max(100),
+});
+
+export function AddDeviceDialog() {
+  const [loading, setLoading] = useState(false);
+  const { showSuccessToast, showErrorToast } = useCustomToast();
+
+  const methods = useForm<{ name: string }>({
+    resolver: zodResolver(DeviceSchema),
+    defaultValues: { name: "" },
+    mode: "onChange",
+  });
+
+  const { handleSubmit, control, reset } = methods;
+
+  const handleSubmitAction = async (data: { name: string }) => {
+    setLoading(true);
+    try {
+      const response = await addDeviceAction(data.name);
+      if (response.status === "error") {
+        showErrorToast({ title: "Error", description: response.message });
+      } else {
+        showSuccessToast({ title: "Success", description: response.message });
+        reset();
+      }
+    } catch (err) {
+      showErrorToast({ title: "Error", description: "Failed to add device" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Add Device</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Device</DialogTitle>
+          <DialogDescription>Specify device name</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(handleSubmitAction)} className="space-y-4">
+          <FormProvider {...methods}>
+            <InputFormField name="name" label="Name" type="text" control={control} />
+          </FormProvider>
+          <DialogFooter className="pt-2">
+            <Button type="submit" disabled={loading}>Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/dialogs/AddServiceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddServiceDialog.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useState } from "react";
+import useCustomToast from "@/hooks/useCustomToast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import InputFormField from "@/components/InputFormField";
+import addServiceAction from "@/actions/dashboard/addServiceAction";
+import getDevicesAction from "@/actions/dashboard/getDevicesAction";
+import { useEffect, useState as useReactState } from "react";
+
+const ServiceSchema = z.object({
+  device: z.string().min(1),
+  name: z.string().min(1, { message: "Name is required" }).max(100),
+  cost: z
+    .string()
+    .transform((v) => parseFloat(v))
+    .refine((v) => !isNaN(v) && v >= 0, { message: "Cost must be positive" }),
+});
+
+export function AddServiceDialog() {
+  const [loading, setLoading] = useState(false);
+  const { showSuccessToast, showErrorToast } = useCustomToast();
+  const [devices, setDevices] = useReactState<any[]>([]);
+
+  useEffect(() => {
+    getDevicesAction(1, 100).then((res) => {
+      if (res.status === "success") {
+        setDevices(res.items);
+      }
+    });
+  }, []);
+
+  const methods = useForm<{ device: string; name: string; cost: number }>({
+    resolver: zodResolver(ServiceSchema),
+    defaultValues: { device: "", name: "", cost: 0 },
+    mode: "onChange",
+  });
+
+  const { handleSubmit, control, reset } = methods;
+
+  const handleSubmitAction = async (data: { device: string; name: string; cost: number }) => {
+    setLoading(true);
+    try {
+      const response = await addServiceAction(data.device, data.name, data.cost);
+      if (response.status === "error") {
+        showErrorToast({ title: "Error", description: response.message });
+      } else {
+        showSuccessToast({ title: "Success", description: response.message });
+        reset();
+      }
+    } catch (err) {
+      showErrorToast({ title: "Error", description: "Failed to add service" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Add Service</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Service</DialogTitle>
+          <DialogDescription>Service details</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(handleSubmitAction)} className="space-y-4">
+          <FormProvider {...methods}>
+            <InputFormField name="name" label="Name" type="text" control={control} />
+            <InputFormField name="cost" label="Cost" type="number" control={control} />
+            <div className="flex flex-col gap-2">
+              <label className="text-sm" htmlFor="device">Device</label>
+              <select id="device" {...methods.register("device")}
+                className="border rounded px-3 py-2">
+                <option value="">Select</option>
+                {devices.map((d) => (
+                  <option key={d._id} value={d._id}>{d.name}</option>
+                ))}
+              </select>
+            </div>
+          </FormProvider>
+          <DialogFooter className="pt-2">
+            <Button type="submit" disabled={loading}>Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/initAdmin.ts
+++ b/src/lib/initAdmin.ts
@@ -1,0 +1,24 @@
+import bcrypt from 'bcryptjs';
+import { connectToDatabase } from './dbConnect';
+import User from '../models/User';
+
+export async function ensureDefaultAdmin() {
+  try {
+    await connectToDatabase();
+    const existing = await User.findOne({ email: 'admin' });
+    if (!existing) {
+      const passwordHash = await bcrypt.hash('admin123#', 10);
+      const admin = new User({
+        name: 'Administrator',
+        email: 'admin',
+        role: 'admin',
+        image: '/admin.png',
+        passwordHash,
+      });
+      await admin.save();
+      console.log('Default admin created');
+    }
+  } catch (err) {
+    console.error('Error ensuring default admin:', err);
+  }
+}

--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -1,0 +1,18 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IDevice extends Document {
+  name: string;
+}
+
+const DeviceSchema: Schema<IDevice> = new Schema(
+  {
+    name: { type: String, required: true, unique: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Device = mongoose.models.Device || mongoose.model<IDevice>('Device', DeviceSchema);
+
+export default Device;

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -1,0 +1,22 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IService extends Document {
+  device: mongoose.Types.ObjectId;
+  name: string;
+  cost: number;
+}
+
+const ServiceSchema: Schema<IService> = new Schema(
+  {
+    device: { type: mongoose.Types.ObjectId, ref: 'Device', required: true },
+    name: { type: String, required: true },
+    cost: { type: Number, required: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Service = mongoose.models.Service || mongoose.model<IService>('Service', ServiceSchema);
+
+export default Service;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,18 @@ type Status = 'Pending' | 'In Progress' | 'Completed';
 
 type UserRole = "admin" | "user" | "worker";
 
+interface Device {
+  _id?: string;
+  name: string;
+}
+
+interface Service {
+  _id?: string;
+  device: string;
+  name: string;
+  cost: number;
+}
+
 interface AddTaskActionParams {
   description: string;
   totalCost: number;
@@ -16,5 +28,5 @@ interface AddTaskActionParams {
   laptopModel: string;
 }
 
-export type { SearchParams, AddTaskActionParams, Status, UserRole };
+export type { SearchParams, AddTaskActionParams, Status, UserRole, Device, Service };
 


### PR DESCRIPTION
## Summary
- create `Device` and `Service` models
- add CRUD actions and tables for devices and services
- add admin pages with forms for managing devices and services
- seed default admin on startup
- link new pages in sidebar

## Testing
- `npm install`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9f16f8083228fdb3efd44f9b5e6