### PR TITLE
Add global route spinner

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from "@/components/ui/spinner";
+
+export default function Loading() {
+  return <Spinner />;
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+export default function Spinner() {
+  return (
+    <div className="flex items-center justify-center w-full py-20">
+      <svg
+        className="animate-spin h-8 w-8 text-primary"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        ></circle>
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        ></path>
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a global loading.tsx page
- implement a simple spinner component for load states

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b1b7e84c8322b1d40af71434b0ca