### PR TITLE
Fix misc lint and typing issues

### DIFF
--- a/src/components/InputFormField.tsx
+++ b/src/components/InputFormField.tsx
@@ -7,14 +7,21 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@radix-ui/react-label";
 import { Textarea } from "@/components/ui/textarea";
 import { TbPhotoCirclePlus } from "react-icons/tb";
+import type {
+  Control,
+  FieldErrors,
+  FieldValues,
+  Path,
+  ControllerRenderProps,
+} from "react-hook-form";
 
-interface InputFormFieldProps {
-  control: any;
-  name: string;
+interface InputFormFieldProps<TFieldValues extends FieldValues = FieldValues> {
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
   id: string;
   placeholder?: string;
   label: string;
-  errors: any;
+  errors: FieldErrors<TFieldValues>;
   type?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   imageSrc?: string;
@@ -22,7 +29,7 @@ interface InputFormFieldProps {
   rows?: number; // Optional for Textarea size
 }
 
-const InputFormField = ({
+const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
   control,
   name,
   id,
@@ -34,10 +41,12 @@ const InputFormField = ({
   imageSrc,
   isImageField = false, // Default is false, meaning it's a regular field
   rows = 4, // Default textarea size
-}: InputFormFieldProps): ReactElement => {
+}: InputFormFieldProps<TFieldValues>): ReactElement => {
 
   // Render Textarea if the field is of type "description" or if specified
-  const renderTextarea = (field: any) => (
+  const renderTextarea = (
+    field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>,
+  ) => (
     <Textarea
       key={id + name}
       id={id}
@@ -49,12 +58,16 @@ const InputFormField = ({
   );
 
   // Render regular Input field
-  const renderInput = (field: any) => (
+  const renderInput = (
+    field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>,
+  ) => (
     <Input key={id + name} id={id} placeholder={placeholder} type={type} {...field} />
   );
 
   // Render the image input for profile image field
-  const renderImageInput = (field: any) => (
+  const renderImageInput = (
+    field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>,
+  ) => (
     <FormItem className="col-span-2">
       <Label
         htmlFor={id}
@@ -76,10 +89,12 @@ const InputFormField = ({
           type="file"
           className="opacity-0 size-0 absolute"
           accept="image/*"
-          onChange={(event) => {
-            field.onChange(event?.target?.files ? event.target.files[0] : null);
-            onChange && onChange(event);
-          }}
+            onChange={(event) => {
+              field.onChange(event?.target?.files ? event.target.files[0] : null);
+              if (onChange) {
+                onChange(event);
+              }
+            }}
           onBlur={field.onBlur}
           name={field.name}
           ref={field.ref}

--- a/src/components/dashboard/DeviceTable.tsx
+++ b/src/components/dashboard/DeviceTable.tsx
@@ -22,7 +22,7 @@ export default function DeviceTable({
   totalItemsLength: number;
   page: string | string[];
   per_page: string | string[];
-  deleteAction: (id: string) => void;
+  deleteAction: (id: string) => Promise<{ message: string; status: string }>;
 }) {
   const start = (Number(page) - 1) * Number(per_page);
   const totalPages = Math.ceil(totalItemsLength / Number(per_page));

--- a/src/components/dashboard/ServiceTable.tsx
+++ b/src/components/dashboard/ServiceTable.tsx
@@ -22,7 +22,7 @@ export default function ServiceTable({
   totalItemsLength: number;
   page: string | string[];
   per_page: string | string[];
-  deleteAction: (id: string) => void;
+  deleteAction: (id: string) => Promise<{ message: string; status: string }>;
 }) {
   const start = (Number(page) - 1) * Number(per_page);
   const totalPages = Math.ceil(totalItemsLength / Number(per_page));

--- a/src/components/dashboard/dialogs/AddDeviceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddDeviceDialog.tsx
@@ -43,8 +43,11 @@ export function AddDeviceDialog() {
         showSuccessToast({ title: "Success", description: response.message });
         reset();
       }
-    } catch (err) {
-      showErrorToast({ title: "Error", description: "Failed to add device" });
+    } catch (error) {
+      showErrorToast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to add device",
+      });
     } finally {
       setLoading(false);
     }

--- a/src/components/dashboard/dialogs/AddServiceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddServiceDialog.tsx
@@ -18,6 +18,7 @@ import InputFormField from "@/components/InputFormField";
 import addServiceAction from "@/actions/dashboard/addServiceAction";
 import getDevicesAction from "@/actions/dashboard/getDevicesAction";
 import { useEffect, useState as useReactState } from "react";
+import { IDevice } from "@/models/Device";
 
 const ServiceSchema = z.object({
   device: z.string().min(1),
@@ -31,7 +32,7 @@ const ServiceSchema = z.object({
 export function AddServiceDialog() {
   const [loading, setLoading] = useState(false);
   const { showSuccessToast, showErrorToast } = useCustomToast();
-  const [devices, setDevices] = useReactState<any[]>([]);
+  const [devices, setDevices] = useReactState<IDevice[]>([]);
 
   useEffect(() => {
     getDevicesAction(1, 100).then((res) => {
@@ -39,7 +40,7 @@ export function AddServiceDialog() {
         setDevices(res.items);
       }
     });
-  }, []);
+  }, [setDevices]);
 
   const methods = useForm<{ device: string; name: string; cost: number }>({
     resolver: zodResolver(ServiceSchema),
@@ -59,8 +60,11 @@ export function AddServiceDialog() {
         showSuccessToast({ title: "Success", description: response.message });
         reset();
       }
-    } catch (err) {
-      showErrorToast({ title: "Error", description: "Failed to add service" });
+    } catch (error) {
+      showErrorToast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to add service",
+      });
     } finally {
       setLoading(false);
     }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,13 +18,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
-
 let count = 0
 
 function genId() {
@@ -32,23 +25,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType["ADD_TOAST"]
+      type: "ADD_TOAST"
       toast: ToasterToast
     }
   | {
-      type: ActionType["UPDATE_TOAST"]
+      type: "UPDATE_TOAST"
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType["DISMISS_TOAST"]
+      type: "DISMISS_TOAST"
       toastId?: ToasterToast["id"]
     }
   | {
-      type: ActionType["REMOVE_TOAST"]
+      type: "REMOVE_TOAST"
       toastId?: ToasterToast["id"]
     }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function serializeData(data: any[]): any[] {
-  return JSON.parse(JSON.stringify(data));
+export function serializeData<T>(data: T[]): T[] {
+  return JSON.parse(JSON.stringify(data)) as T[];
 }
 

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -6,7 +6,7 @@ export interface IService extends Document {
   cost: number;
 }
 
-const ServiceSchema: Schema<IService> = new Schema(
+const ServiceSchema: Schema = new Schema(
   {
     device: { type: mongoose.Types.ObjectId, ref: 'Device', required: true },
     name: { type: String, required: true },


### PR DESCRIPTION
## Summary
- fix Service model schema typing
- tighten types for delete action props
- improve error handling in device/service dialogs
- refine toast reducer action types
- add generic typing to InputFormField
- make `serializeData` generic

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: TypeScript errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_6856b3c486108322abd2f94b798a2ecb