### PR TITLE
Fix admin dialog forms

### DIFF
--- a/src/components/InputFormField.tsx
+++ b/src/components/InputFormField.tsx
@@ -21,7 +21,7 @@ interface InputFormFieldProps<TFieldValues extends FieldValues = FieldValues> {
   id: string;
   placeholder?: string;
   label: string;
-  errors: FieldErrors<TFieldValues>;
+  errors?: FieldErrors<TFieldValues>;
   type?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   imageSrc?: string;
@@ -118,7 +118,7 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
             {field.name === "description1" ? renderTextarea(field) : renderInput(field)}
           </FormControl>
           <FormMessage className="empty:hidden mt-0">
-            {errors[name]?.message}
+            {errors?.[name]?.message}
           </FormMessage>
         </FormItem>
       );

--- a/src/components/dashboard/dialogs/AddDeviceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddDeviceDialog.tsx
@@ -31,7 +31,12 @@ export function AddDeviceDialog() {
     mode: "onChange",
   });
 
-  const { handleSubmit, control, reset } = methods;
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = methods;
 
   const handleSubmitAction = async (data: { name: string }) => {
     setLoading(true);
@@ -65,7 +70,13 @@ export function AddDeviceDialog() {
         </DialogHeader>
         <form onSubmit={handleSubmit(handleSubmitAction)} className="space-y-4">
           <FormProvider {...methods}>
-            <InputFormField name="name" label="Name" type="text" control={control} />
+            <InputFormField
+              name="name"
+              label="Name"
+              type="text"
+              control={control}
+              errors={errors}
+            />
           </FormProvider>
           <DialogFooter className="pt-2">
             <Button type="submit" disabled={loading}>Save</Button>

--- a/src/components/dashboard/dialogs/AddServiceDialog.tsx
+++ b/src/components/dashboard/dialogs/AddServiceDialog.tsx
@@ -48,7 +48,12 @@ export function AddServiceDialog() {
     mode: "onChange",
   });
 
-  const { handleSubmit, control, reset } = methods;
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = methods;
 
   const handleSubmitAction = async (data: { device: string; name: string; cost: number }) => {
     setLoading(true);
@@ -82,8 +87,20 @@ export function AddServiceDialog() {
         </DialogHeader>
         <form onSubmit={handleSubmit(handleSubmitAction)} className="space-y-4">
           <FormProvider {...methods}>
-            <InputFormField name="name" label="Name" type="text" control={control} />
-            <InputFormField name="cost" label="Cost" type="number" control={control} />
+            <InputFormField
+              name="name"
+              label="Name"
+              type="text"
+              control={control}
+              errors={errors}
+            />
+            <InputFormField
+              name="cost"
+              label="Cost"
+              type="number"
+              control={control}
+              errors={errors}
+            />
             <div className="flex flex-col gap-2">
               <label className="text-sm" htmlFor="device">Device</label>
               <select id="device" {...methods.register("device")}


### PR DESCRIPTION
## Summary
- avoid runtime errors when `errors` prop is missing in `InputFormField`
- expose errors in AddServiceDialog and AddDeviceDialog so validation messages appear

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run build` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856b60e4cec83229fbe45dd192867e0