### PR TITLE
Add task details page for admin panel

### DIFF
--- a/src/actions/dashboard/getTaskByIdAction.ts
+++ b/src/actions/dashboard/getTaskByIdAction.ts
@@ -1,0 +1,29 @@
+"use server";
+import { connectToDatabase } from "@/lib/dbConnect";
+import Task from "@/models/Task";
+
+const getTaskByIdAction = async (taskId: string) => {
+  try {
+    if (!taskId) {
+      return { status: "error", message: "Task ID is required" };
+    }
+
+    await connectToDatabase();
+
+    const task = await Task.findById(taskId).lean();
+
+    if (!task) {
+      return { status: "error", message: "Task not found" };
+    }
+
+    return { status: "success", item: JSON.parse(JSON.stringify(task)) };
+  } catch (error) {
+    console.error("Error fetching task:", error);
+    return {
+      status: "error",
+      message: (error as { message: string }).message || "Internal server error.",
+    };
+  }
+};
+
+export default getTaskByIdAction;

--- a/src/app/admin/tasks/[id]/page.tsx
+++ b/src/app/admin/tasks/[id]/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from "next/navigation";
+import DashboardContainer from "@/components/dashboard/DashboardContainer";
+import DashboardHeader from "@/components/dashboard/DashboardHeader";
+import DashboardContent from "@/components/dashboard/DashboardContent";
+import DashboardTitle from "@/components/dashboard/DashboardTitle";
+import getTaskByIdAction from "@/actions/dashboard/getTaskByIdAction";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function TaskDetailsPage({ params }: PageProps) {
+  const { id } = await params;
+  const response = await getTaskByIdAction(id);
+
+  if (response.status === "error" || !response.item) {
+    notFound();
+  }
+
+  const task = response.item;
+
+  return (
+    <DashboardContainer className="w-full min-h-screen py-12 px-10 overflow-y-auto">
+      <DashboardHeader>
+        <DashboardTitle>Task Details</DashboardTitle>
+      </DashboardHeader>
+      <DashboardContent>
+        <div className="bg-background shadow p-6 rounded-lg space-y-3">
+          <p><span className="font-semibold">Description:</span> {task.description}</p>
+          <p><span className="font-semibold">Customer:</span> {task.customerName}</p>
+          <p><span className="font-semibold">Phone:</span> {task.customerPhone}</p>
+          <p><span className="font-semibold">Brand:</span> {task.laptopBrand}</p>
+          <p><span className="font-semibold">Model:</span> {task.laptopModel}</p>
+          <p><span className="font-semibold">Serial:</span> {task.serialNumber}</p>
+          <p><span className="font-semibold">Status:</span> {task.status}</p>
+          <p><span className="font-semibold">Cost:</span> ${task.totalCost}</p>
+          <p><span className="font-semibold">Created:</span> {new Date(task.createdAt).toLocaleString()}</p>
+        </div>
+      </DashboardContent>
+    </DashboardContainer>
+  );
+}

--- a/src/components/dashboard/TaskTable.tsx
+++ b/src/components/dashboard/TaskTable.tsx
@@ -3,6 +3,7 @@ import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { ITask } from "@/models/Task";
 import DeleteButton from "@/components/dashboard/buttons/DeleteButton";
+import ViewButton from "@/components/dashboard/buttons/ViewButton";
 import {
   Table,
   TableBody,
@@ -87,7 +88,7 @@ export default function TaskTable({
                 ${totalCost}
               </TableCell>
               {(role === "admin" || role === "worker") && !hideActions && (
-                <TableCell className="text-right">
+                <TableCell className="flex gap-2 justify-end">
                   {role === "admin" ? (
                     <DeleteButton
                       // @ts-ignore
@@ -97,6 +98,7 @@ export default function TaskTable({
                   ) : role === "worker" ? (
                     <UpdateStatusSelect taskId={_id as unknown as string} />
                   ) : null}
+                  <ViewButton href={`/admin/tasks/${_id?.toString()}`}/>
                 </TableCell>
               )}
             </TableRow>

--- a/src/components/dashboard/buttons/ViewButton.tsx
+++ b/src/components/dashboard/buttons/ViewButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { ReactElement } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { MdRemoveRedEye } from "react-icons/md";
+
+export default function ViewButton({ href }: { href: string }): ReactElement {
+  return (
+    <Button asChild size="sm" variant="ghost" className="bg-transparent">
+      <Link href={href}>
+        <MdRemoveRedEye className="text-foreground text-lg" />
+      </Link>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add action to fetch a single task
- add page under `/admin/tasks/[id]` to display task details
- add `ViewButton` component
- show View button in task table

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build` *(fails: existing TypeScript errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3df8b488322a07ee62cd4d0d0c1