### PR TITLE
Add worker account creation for admins

### DIFF
--- a/src/actions/dashboard/addUserAction.ts
+++ b/src/actions/dashboard/addUserAction.ts
@@ -1,0 +1,43 @@
+"use server"
+import { connectToDatabase } from "@/lib/dbConnect";
+import User from "@/models/User";
+import bcrypt from "bcryptjs";
+import { checkUserPermission } from "@/services";
+
+const addUserAction = async (
+  name: string,
+  email: string,
+  password: string,
+  role: "worker" = "worker"
+) => {
+  try {
+    const permissionCheck = await checkUserPermission("admin");
+    if (permissionCheck.status === "error") {
+      return permissionCheck;
+    }
+
+    await connectToDatabase();
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      return { status: "error", message: "User with this email already exists." };
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = new User({
+      name,
+      email,
+      role,
+      image: `https://i.pravatar.cc/150?u=${email}`,
+      passwordHash,
+    });
+    await user.save();
+
+    return { status: "success", message: "User created successfully." };
+  } catch (error) {
+    console.error("Error adding user:", error);
+    return { status: "error", message: (error as { message: string }).message || "Internal server error." };
+  }
+};
+
+export default addUserAction;

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -8,6 +8,7 @@ import DashboardTitle from "@/components/dashboard/DashboardTitle";
 import getUsersAction from "@/actions/dashboard/getUsersAction"
 import { SearchParams } from "@/types"
 import deleteUserAction from "@/actions/dashboard/deleteUserAction";
+import { AddUserDialog } from "@/components/dashboard/dialogs/AddUserDialog";
 
 const UsersPage = async ({
   searchParams,
@@ -27,6 +28,7 @@ const UsersPage = async ({
           <DashboardTitle>Users</DashboardTitle>
           <div className="flex gap-6">
             <SelectShowing />
+            <AddUserDialog />
           </div>
         </DashboardHeader>
         <DashboardContent className="bg-background shadow p-6 rounded-lg">

--- a/src/components/dashboard/dialogs/AddUserDialog.tsx
+++ b/src/components/dashboard/dialogs/AddUserDialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+import { useState } from "react";
+import useCustomToast from "@/hooks/useCustomToast";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import InputFormField from "@/components/InputFormField";
+import addUserAction from "@/actions/dashboard/addUserAction";
+
+const UserSchema = z.object({
+  name: z.string().min(1, { message: "Name is required" }).max(100),
+  email: z.string().email({ message: "Invalid email" }),
+  password: z.string().min(6, { message: "Password must be at least 6 characters" }),
+});
+
+type UserForm = z.infer<typeof UserSchema>;
+
+export function AddUserDialog() {
+  const [loading, setLoading] = useState(false);
+  const { showSuccessToast, showErrorToast } = useCustomToast();
+
+  const methods = useForm<UserForm>({
+    resolver: zodResolver(UserSchema),
+    defaultValues: { name: "", email: "", password: "" },
+    mode: "onChange",
+  });
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = methods;
+
+  const handleSubmitAction = async (data: UserForm) => {
+    setLoading(true);
+    try {
+      const response = await addUserAction(data.name, data.email, data.password);
+      if (response.status === "error") {
+        showErrorToast({ title: "Error", description: response.message });
+      } else {
+        showSuccessToast({ title: "Success", description: response.message });
+        reset();
+      }
+    } catch (error) {
+      showErrorToast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to add user",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Add Worker</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Worker</DialogTitle>
+          <DialogDescription>Provide worker credentials</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(handleSubmitAction)} className="space-y-4">
+          <FormProvider {...methods}>
+            <InputFormField
+              name="name"
+              label="Name"
+              id="name"
+              type="text"
+              control={control}
+              errors={errors}
+            />
+            <InputFormField
+              name="email"
+              label="Email"
+              id="email"
+              type="text"
+              control={control}
+              errors={errors}
+            />
+            <InputFormField
+              name="password"
+              label="Password"
+              id="password"
+              type="password"
+              control={control}
+              errors={errors}
+            />
+          </FormProvider>
+          <DialogFooter className="pt-2">
+            <Button type="submit" disabled={loading}>
+              {loading ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- enable admins to create worker logins
- add dialog to create workers in the users page

## Testing
- `npm install`
- `npm run lint` *(fails: many ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685702e087248322ab22b36d356c390c