### PR TITLE
Configure pravatar host for Next.js images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "i.pravatar.cc",
+      },
     ],
   },
   async headers() {


### PR DESCRIPTION
## Summary
- allow images from `i.pravatar.cc` in `next.config.ts`

## Testing
- `npm run lint` *(fails: ESLint found multiple errors)*
- `npm run build` *(fails: could not find a declaration file for `bcryptjs`)*

------
https://chatgpt.com/codex/tasks/task_e_685706e68c2c8322a26630c90be49806