### PR TITLE
Fix locale redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,13 @@
 import { NextConfig } from "next";
+import { locales, defaultLocale } from "./i18n";
 
 const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  i18n: {
+    locales,
+    defaultLocale,
   },
   images: {
     remotePatterns: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+import { defaultLocale } from '../i18n'
+
+export default function Index() {
+  redirect(`/${defaultLocale}`)
+}


### PR DESCRIPTION
## Summary
- configure i18n locales in Next.js config
- add root page redirecting to default locale

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68571646e8a08322b08ae78899e2548e