### PR TITLE
Fix i18n import in root page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { defaultLocale } from '../i18n'
+import { defaultLocale } from '../../i18n'
 
 export default function Index() {
   redirect(`/${defaultLocale}`)


### PR DESCRIPTION
## Summary
- fix invalid relative import for `i18n` in `src/app/page.tsx`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857178338188322ae2a9f066a1c1d45