### PR TITLE
Fix infinite locale redirect

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,2 +1,5 @@
 export const locales = ['en', 'ru'] as const;
 export const defaultLocale = 'en';
+// Always require a locale prefix in the URL to avoid redirect loops
+export const localePrefix = 'always';
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,14 @@
 import createMiddleware from 'next-intl/middleware';
-import { locales, defaultLocale } from './i18n';
+import { locales, defaultLocale, localePrefix } from './i18n';
 
 export default createMiddleware({
   locales: locales as unknown as string[],
   defaultLocale,
   localeDetection: true,
+  localePrefix,
 });
 
 export const config = {
   matcher: ['/((?!api|_next|.*\\..*).*)'],
 };
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
   i18n: {
     locales,
     defaultLocale,
+    localeDetection: false,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- require a locale prefix in URLs to prevent redirects
- configure `next.config.ts` to disable Next.js locale detection

## Testing
- `bun run lint` *(fails: Unexpected any, etc.)*
- `bun run dev`

------
https://chatgpt.com/codex/tasks/task_e_685718f850808322aee3557bbe6459d5