### PR TITLE
Fix MongoDB connection caching and add service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,3 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+


### PR DESCRIPTION
## Summary
- reuse MongoDB connection instead of connecting on every request
- add simple service worker placeholder to avoid 404 errors

## Testing
- `npx next lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68571d1f172c832291a204c016b7698c