### PR TITLE
Remove extra phone input border

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -314,4 +314,11 @@
   .phone-input .PhoneInputInput {
     @apply flex-1 bg-transparent outline-none text-base placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm;
   }
+  .phone-input .PhoneInputCountryIcon--border {
+    box-shadow: none;
+    background-color: transparent;
+  }
+  .phone-input .PhoneInputCountrySelect:focus + .PhoneInputCountryIcon--border {
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
## Summary
- disable default flag border for phone input

## Testing
- `npm run lint` *(fails: unexpected any, ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68572ef38f9c832290b4b7b8d339ed30