### PR TITLE
Hide required messages in form fields

### DIFF
--- a/src/components/InputFormField.tsx
+++ b/src/components/InputFormField.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ReactElement, memo } from "react";
-import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { FormControl, FormField, FormItem } from "@/components/ui/form";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@radix-ui/react-label";
@@ -38,7 +38,7 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
   id,
   placeholder,
   label,
-  errors,
+  errors: _errors,
   type = "text",
   onChange,
   imageSrc,
@@ -46,6 +46,7 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
   rows = 4, // Default textarea size
   isTextarea = false,
 }: InputFormFieldProps<TFieldValues>): ReactElement => {
+  void _errors;
 
   // Render Textarea if the field is of type "description" or if specified
   const renderTextarea = (
@@ -121,9 +122,6 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
           <FormControl>
             {isTextarea ? renderTextarea(field) : renderInput(field)}
           </FormControl>
-          <FormMessage className="empty:hidden mt-0">
-            {errors?.[name]?.message}
-          </FormMessage>
         </FormItem>
       );
     }} />

--- a/src/components/PhoneInputField.tsx
+++ b/src/components/PhoneInputField.tsx
@@ -9,7 +9,6 @@ import {
   FormItem,
   FormLabel,
   FormControl,
-  FormMessage,
 } from '@/components/ui/form'
 import { Control, FieldValues, Path } from 'react-hook-form'
 
@@ -51,7 +50,6 @@ const PhoneInputField = <TFieldValues extends FieldValues = FieldValues>({
               countryCallingCodeEditable={false}
             />
           </FormControl>
-          <FormMessage />
         </FormItem>
       )}
     />


### PR DESCRIPTION
## Summary
- hide validation message output in `InputFormField`
- hide validation message output in `PhoneInputField`

## Testing
- `npm run lint` *(fails: Unexpected any, ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6857361e8fa08322b6be5b9672238185