### PR TITLE
Filter digits from client name input

### DIFF
--- a/src/components/InputFormField.tsx
+++ b/src/components/InputFormField.tsx
@@ -59,6 +59,12 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
       className="resize-none"
       rows={rows}
       {...field}
+      onChange={(event) => {
+        if (onChange) {
+          onChange(event)
+        }
+        field.onChange(event)
+      }}
     />
   );
 
@@ -66,7 +72,19 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
   const renderInput = (
     field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>,
   ) => (
-    <Input key={id + name} id={id} placeholder={placeholder} type={type} {...field} />
+    <Input
+      key={id + name}
+      id={id}
+      placeholder={placeholder}
+      type={type}
+      {...field}
+      onChange={(event) => {
+        if (onChange) {
+          onChange(event)
+        }
+        field.onChange(event)
+      }}
+    />
   );
 
   // Render the image input for profile image field
@@ -95,10 +113,10 @@ const InputFormField = <TFieldValues extends FieldValues = FieldValues>({
           className="opacity-0 size-0 absolute"
           accept="image/*"
             onChange={(event) => {
-              field.onChange(event?.target?.files ? event.target.files[0] : null);
               if (onChange) {
                 onChange(event);
               }
+              field.onChange(event?.target?.files ? event.target.files[0] : null);
             }}
           onBlur={field.onBlur}
           name={field.name}

--- a/src/components/RequestForm.tsx
+++ b/src/components/RequestForm.tsx
@@ -32,7 +32,8 @@ const TaskSchema = z.object({
   customerName: z
     .string()
     .min(1, { message: 'Имя клиента обязательно' })
-    .max(100, { message: 'Имя клиента не должно превышать 100 символов' }),
+    .max(100, { message: 'Имя клиента не должно превышать 100 символов' })
+    .regex(/^[^0-9]*$/, { message: 'Имя клиента не должно содержать цифры' }),
   customerPhone: z
     .string()
     .min(1, { message: 'Телефон клиента обязателен' })
@@ -173,6 +174,9 @@ export default function RequestForm() {
           id="customerName"
           label="Имя клиента"
           errors={errors}
+          onChange={(e) => {
+            e.target.value = e.target.value.replace(/\d+/g, '')
+          }}
         />
 
         <PhoneInputField


### PR DESCRIPTION
## Summary
- prevent digits in customer name field
- forward custom input handlers in InputFormField

## Testing
- `npm run lint` *(fails: do not use "@ts-ignore" / unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68573ab50c64832299adcc79953d1989