### PR TITLE
Fix MissingSchemaError for populated category

### DIFF
--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -1,4 +1,5 @@
 import mongoose, { Schema, Document } from 'mongoose';
+import '@/models/Category';
 
 export interface IDevice extends Document {
   category: mongoose.Types.ObjectId;

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -1,4 +1,5 @@
 import mongoose, { Schema, Document } from 'mongoose';
+import '@/models/Category';
 
 export interface IService extends Document {
   category: mongoose.Types.ObjectId;


### PR DESCRIPTION
## Summary
- ensure Category schema is loaded whenever Device or Service models are imported

## Testing
- `pnpm lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68573d93c3908322b2884dc1fc9b1b93