### PR TITLE
Allow creating tasks without workers

### DIFF
--- a/src/actions/dashboard/addTaskAction.ts
+++ b/src/actions/dashboard/addTaskAction.ts
@@ -23,17 +23,24 @@ export default async function addTaskAction({
     await connectToDatabase();
 
     const worker = await getWorkerWithLeastTasks();
-    if (!worker) {
-      return { status: 'error', message: 'No workers available to assign the task to.' };
+
+    const newTask = await createTask(
+      { description, totalCost, customerName, customerPhone, laptopBrand, laptopModel },
+      worker,
+    );
+
+    if (worker) {
+      await assignTaskToWorker(worker, newTask._id as mongoose.Types.ObjectId);
     }
-
-    const newTask = await createTask({ description, totalCost, customerName, customerPhone, laptopBrand, laptopModel }, worker);
-
-    await assignTaskToWorker(worker, newTask._id as mongoose.Types.ObjectId);
 
     revalidateTag('/admin');
 
-    return { status: 'success', message: 'Task created and assigned successfully!' };
+    return {
+      status: 'success',
+      message: worker
+        ? 'Task created and assigned successfully!'
+        : 'Task created successfully, but no worker was available for assignment.',
+    };
   } catch (error) {
     return { status: 'error', message: (error as Error).message || 'Internal server error.' };
   }

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -99,10 +99,13 @@ export async function sendInvoiceToWhatsApp(invoiceDetails: {
   }
 }
 
-export const createTask = async (params: AddTaskActionParams, worker: IUser): Promise<ITask> => {
+export const createTask = async (
+  params: AddTaskActionParams,
+  worker?: IUser | null,
+): Promise<ITask> => {
   const newTask = new Task({
     ...params,
-    workerId: worker._id,
+    workerId: worker?._id ?? null,
     status: 'Pending',
   });
   await newTask.save();

--- a/src/types/bcryptjs.d.ts
+++ b/src/types/bcryptjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'bcryptjs';


### PR DESCRIPTION
## Summary
- allow task creation when there are no workers
- skip assignment if no worker is available
- add module declaration for bcryptjs

## Testing
- `npm run build` *(fails: Type error in src/app/admin/categories/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6857421ea9f48322b12d3b95af2c1646