### PR TITLE
Fix tasks fetching handler

### DIFF
--- a/src/handlers/taskHandlers.ts
+++ b/src/handlers/taskHandlers.ts
@@ -1,10 +1,11 @@
-import User from '../models/User';
+import Task from '../models/Task';
+import { Socket } from 'socket.io';
 
-export const handleTaskEvents = (socket: any) => {
+export const handleTaskEvents = (socket: Socket) => {
   socket.on('getAllTasks', async () => {
     try {
-      const users = await User.find();
-      socket.emit('tasksList', users);
+      const tasks = await Task.find();
+      socket.emit('tasksList', tasks);
     } catch (error) {
       console.error('Error fetching tasks:', error);
       socket.emit('error', 'Failed to fetch tasks');


### PR DESCRIPTION
## Summary
- correct socket handler to load tasks instead of users
- type socket with `Socket` interface

## Testing
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857480088088322a4c9b59b35c0b09e