### PR TITLE
Add homepage sections and layout elements

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Toaster } from "@/components/ui/toaster"
+import { Toaster } from "@/components/ui/toaster";
 import AppProvider from "@/providers/AppProvider";
 import "./globals.css";
-import Providers from "./providers"
-import { getSession } from "@/auth"
-import { ensureDefaultAdmin } from "@/lib/initAdmin"
+import Providers from "./providers";
+import { getSession } from "@/auth";
+import { ensureDefaultAdmin } from "@/lib/initAdmin";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -38,7 +40,9 @@ export default async function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
           <Providers session={session}>
+            <Header />
             <div className="w-svw">{children}</div>
+            <Footer />
             <Toaster />
           </Providers>
         </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,15 @@
 import Hero from "@/components/home/Hero";
+import About from "@/components/home/About";
+import Reviews from "@/components/home/Reviews";
+import Contacts from "@/components/home/Contacts";
 
 export default function Home() {
   return (
     <>
       <Hero />
+      <About />
+      <Reviews />
+      <Contacts />
     </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,19 +16,16 @@ export default function Header() {
         <span className="text-2xl font-semibold">Best Electronics</span>
       </Link>
       <div className="hidden md:flex gap-4">
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#hero" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           Главная
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#about" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           О нас
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-          Услуги
+        <Link href="#reviews" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+          Отзывы
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-          Портфолио
-        </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#contacts" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           Контакты
         </Link>
       </div>
@@ -46,19 +43,16 @@ export default function Header() {
               <SheetTitle>Меню</SheetTitle>
             </VisuallyHidden.Root>
             <div className="grid w-[200px] p-4">
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#hero" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 Главная
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#about" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 О нас
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-                Услуги
+              <Link href="#reviews" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+                Отзывы
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-                Портфолио
-              </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#contacts" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 Контакты
               </Link>
             </div>

--- a/src/components/home/About.tsx
+++ b/src/components/home/About.tsx
@@ -1,0 +1,16 @@
+import BaseContainer from "@/components/BaseContainer";
+
+export default function About() {
+  return (
+    <section id="about" className="py-20">
+      <BaseContainer className="text-center space-y-4">
+        <h2 className="text-3xl font-bold">О компании</h2>
+        <p className="max-w-2xl mx-auto">
+          Best Electronics специализируется на ремонте и модернизации ноутбуков и
+          другой электроники. Мы ценим качество работы и предлагаем индивидуальный
+          подход к каждому клиенту.
+        </p>
+      </BaseContainer>
+    </section>
+  );
+}

--- a/src/components/home/Contacts.tsx
+++ b/src/components/home/Contacts.tsx
@@ -1,0 +1,26 @@
+import BaseContainer from "@/components/BaseContainer";
+import Link from "next/link";
+
+export default function Contacts() {
+  return (
+    <section id="contacts" className="py-20">
+      <BaseContainer className="text-center space-y-4">
+        <h2 className="text-3xl font-bold">Контакты</h2>
+        <p>Кулатова 8/1, Бишкек</p>
+        <p>
+          <a href="tel:+996501313114" className="underline">
+            +996 501‑31‑31‑14
+          </a>{' '}|
+          <a href="tel:+996557313114" className="underline">
+            +996 557‑31‑31‑14
+          </a>
+        </p>
+        <p>
+          <Link href="https://go.2gis.com/" className="underline" target="_blank">
+            Посмотреть на карте
+          </Link>
+        </p>
+      </BaseContainer>
+    </section>
+  );
+}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -32,6 +32,7 @@ const Hero: React.FC = () => {
 
   return (
     <section
+      id="hero"
       className="relative bg-background h-screen flex items-center justify-center text-foreground bg-cover bg-center"
     >
       <div className="relative flex flex-col items-center text-center px-6 z-10">

--- a/src/components/home/Reviews.tsx
+++ b/src/components/home/Reviews.tsx
@@ -1,0 +1,24 @@
+import BaseContainer from "@/components/BaseContainer";
+
+const data = [
+  { id: 1, author: "Айзат", text: "Отличный сервис и быстрый ремонт." },
+  { id: 2, author: "Бек", text: "Помогли вернуть ноутбук к жизни." },
+];
+
+export default function Reviews() {
+  return (
+    <section id="reviews" className="py-20 bg-muted/50">
+      <BaseContainer>
+        <h2 className="text-3xl font-bold text-center mb-6">Отзывы клиентов</h2>
+        <ul className="space-y-4">
+          {data.map((r) => (
+            <li key={r.id} className="p-4 bg-background rounded">
+              <p className="italic">"{r.text}"</p>
+              <p className="text-right font-semibold">— {r.author}</p>
+            </li>
+          ))}
+        </ul>
+      </BaseContainer>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- show `Header` and `Footer` inside the root layout
- add About, Reviews and Contacts sections for the home page
- place new sections after the hero component
- update navigation links to anchor to the respective sections

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68574ff6edb48322afd8563e354147e4