### PR TITLE
Add home sections and include header/footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import "./globals.css";
 import Providers from "./providers"
 import { getSession } from "@/auth"
 import { ensureDefaultAdmin } from "@/lib/initAdmin"
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -38,7 +40,9 @@ export default async function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
           <Providers session={session}>
+            <Header />
             <div className="w-svw">{children}</div>
+            <Footer />
             <Toaster />
           </Providers>
         </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,15 @@
 import Hero from "@/components/home/Hero";
+import About from "@/components/home/About";
+import Reviews from "@/components/home/Reviews";
+import Contacts from "@/components/home/Contacts";
 
 export default function Home() {
   return (
     <>
       <Hero />
+      <About />
+      <Reviews />
+      <Contacts />
     </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,23 +12,20 @@ export default function Header() {
 
   return (
     <BaseContainer className="flex items-center justify-between py-6 bg-secondary">
-      <Link href="#" className="flex items-center gap-2" prefetch={false}>
+      <Link href="#hero" className="flex items-center gap-2" prefetch={false}>
         <span className="text-2xl font-semibold">Best Electronics</span>
       </Link>
       <div className="hidden md:flex gap-4">
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#hero" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           Главная
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#about" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           О нас
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-          Услуги
+        <Link href="#reviews" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+          Отзывы
         </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-          Портфолио
-        </Link>
-        <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+        <Link href="#contacts" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
           Контакты
         </Link>
       </div>
@@ -46,19 +43,16 @@ export default function Header() {
               <SheetTitle>Меню</SheetTitle>
             </VisuallyHidden.Root>
             <div className="grid w-[200px] p-4">
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#hero" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 Главная
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#about" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 О нас
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-                Услуги
+              <Link href="#reviews" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+                Отзывы
               </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
-                Портфолио
-              </Link>
-              <Link href="#" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
+              <Link href="#contacts" className="text-lg font-medium hover:underline underline-offset-4" prefetch={false}>
                 Контакты
               </Link>
             </div>

--- a/src/components/home/About.tsx
+++ b/src/components/home/About.tsx
@@ -1,0 +1,16 @@
+"use client";
+import BaseContainer from "@/components/BaseContainer";
+
+export default function About() {
+  return (
+    <section id="about">
+      <BaseContainer className="py-16">
+        <h2 className="text-3xl font-bold mb-4 text-center">О компании</h2>
+        <p className="max-w-2xl mx-auto text-center">
+          Best Electronics занимается ремонтом и модернизацией электроники. Наш опыт
+          позволяет быстро находить решения и гарантировать качество работ.
+        </p>
+      </BaseContainer>
+    </section>
+  );
+}

--- a/src/components/home/Contacts.tsx
+++ b/src/components/home/Contacts.tsx
@@ -1,0 +1,20 @@
+"use client";
+import BaseContainer from "@/components/BaseContainer";
+import Link from "next/link";
+
+export default function Contacts() {
+  return (
+    <section id="contacts">
+      <BaseContainer className="py-16">
+        <h2 className="text-3xl font-bold mb-4 text-center">Контакты</h2>
+        <div className="max-w-xl mx-auto text-center space-y-2">
+          <p>Кыргызстан, г. Бишкек, ул. Примерная, 10</p>
+          <p>
+            Телефон: <Link href="tel:+996000000000" className="underline">+996 000 000 000</Link>
+          </p>
+          <p>Работаем ежедневно с 9:00 до 18:00</p>
+        </div>
+      </BaseContainer>
+    </section>
+  );
+}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -32,6 +32,7 @@ const Hero: React.FC = () => {
 
   return (
     <section
+      id="hero"
       className="relative bg-background h-screen flex items-center justify-center text-foreground bg-cover bg-center"
     >
       <div className="relative flex flex-col items-center text-center px-6 z-10">

--- a/src/components/home/Reviews.tsx
+++ b/src/components/home/Reviews.tsx
@@ -1,0 +1,38 @@
+"use client";
+import BaseContainer from "@/components/BaseContainer";
+
+const reviews = [
+  {
+    id: 1,
+    author: "Алексей",
+    text: "Быстро починили мой ноутбук и дали гарантию на ремонт."
+  },
+  {
+    id: 2,
+    author: "Мария",
+    text: "Отличный сервис и вежливый персонал. Рекомендую всем!"
+  },
+  {
+    id: 3,
+    author: "Игорь",
+    text: "Помогли подобрать комплектующие для апгрейда компьютера."
+  }
+];
+
+export default function Reviews() {
+  return (
+    <section id="reviews">
+      <BaseContainer className="py-16">
+        <h2 className="text-3xl font-bold mb-8 text-center">Отзывы клиентов</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {reviews.map((r) => (
+            <div key={r.id} className="p-4 border rounded-lg shadow-sm">
+              <p className="mb-2 italic">"{r.text}"</p>
+              <p className="text-right font-medium">— {r.author}</p>
+            </div>
+          ))}
+        </div>
+      </BaseContainer>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- wire up Header and Footer in the main layout
- implement About, Reviews and Contacts home sections
- render new sections on the homepage
- add anchor navigation links in Header

## Testing
- `npx next lint` *(fails: Need to install the following packages: next@15.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_68574fba98f48322b45a078fb6f29ed4