### PR TITLE
Improve burger menu animation

### DIFF
--- a/src/components/ClientHeader.tsx
+++ b/src/components/ClientHeader.tsx
@@ -2,13 +2,16 @@
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import Link from "next/link";
 import { RxHamburgerMenu } from "react-icons/rx";
+import { AiOutlineClose } from "react-icons/ai";
 import { Sheet, SheetTrigger, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import BaseContainer from "@/components/BaseContainer";
 import AvatarMenu from "./AvatarMenu";
 import { useSession } from "next-auth/react";
+import { useState } from "react";
 
 export default function ClientHeader() {
   const { data: session } = useSession();
+  const [open, setOpen] = useState(false);
 
   const links = [
     { href: "#hero", label: "Главная" },
@@ -37,24 +40,29 @@ export default function ClientHeader() {
         </nav>
         <div className="flex items-center gap-4 md:hidden">
           {session && <AvatarMenu />}
-          <Sheet>
+          <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>
               <button className="p-2 rounded-md hover:bg-muted">
-                <RxHamburgerMenu className="text-2xl" />
+                {open ? (
+                  <AiOutlineClose className="text-2xl" />
+                ) : (
+                  <RxHamburgerMenu className="text-2xl" />
+                )}
                 <span className="sr-only">Открыть меню</span>
               </button>
             </SheetTrigger>
-            <SheetContent side="left">
+            <SheetContent side="top" className="w-full">
               <VisuallyHidden.Root>
                 <SheetTitle>Меню</SheetTitle>
               </VisuallyHidden.Root>
-              <div className="grid w-[200px] p-4 gap-2">
-                {links.map((link) => (
+              <div className="grid w-full p-4 gap-2" data-state={open ? "open" : "closed"}>
+                {links.map((link, index) => (
                   <Link
                     key={link.href}
                     href={link.href}
                     prefetch={false}
-                    className="text-sm font-medium hover:underline underline-offset-4"
+                    className="text-sm font-medium hover:underline underline-offset-4 opacity-0 animate-menu-slide-down"
+                    style={{ animationDelay: `${index * 100}ms` }}
                   >
                     {link.label}
                   </Link>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -35,7 +35,7 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 w-full border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,10 +84,15 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "menu-slide-down": {
+          from: { transform: "translateY(-10px)", opacity: "0" },
+          to: { transform: "translateY(0)", opacity: "1" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "menu-slide-down": "menu-slide-down 0.3s ease forwards",
       },
     },
   },


### PR DESCRIPTION
## Summary
- show hamburger menu sliding from the top
- animate menu items with a slide-down effect
- show close icon when menu is open
- add menu-slide-down animation in Tailwind config

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npx tsc -p tsconfig.json` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68593be892448322a858abccdb9998d1