### PR TITLE
Fix extra spacing near testimonial carousel

### DIFF
--- a/src/components/home/Reviews.tsx
+++ b/src/components/home/Reviews.tsx
@@ -22,7 +22,7 @@ export default function Reviews() {
     <section id="reviews" className="py-20 bg-muted/50">
       <BaseContainer className="max-w-2xl">
         <h2 className="text-3xl font-bold text-center mb-6">Отзывы клиентов</h2>
-        <Carousel className="relative">
+        <Carousel className="relative overflow-x-hidden">
           <CarouselContent>
             {data.map((r) => (
               <CarouselItem

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -208,7 +208,7 @@ const CarouselPrevious = React.forwardRef<
       className={cn(
         "absolute  h-8 w-8 rounded-full",
         orientation === "horizontal"
-          ? "-left-12 top-1/2 -translate-y-1/2"
+          ? "left-2 sm:-left-12 top-1/2 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}
@@ -237,7 +237,7 @@ const CarouselNext = React.forwardRef<
       className={cn(
         "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
-          ? "-right-12 top-1/2 -translate-y-1/2"
+          ? "right-2 sm:-right-12 top-1/2 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
         className
       )}


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in Reviews carousel
- adjust carousel arrow positions for small screens

## Testing
- `npm run lint` *(fails: Unexpected any, ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68594328808883229f8ac3f85e24caf2