### PR TITLE
Fix Leaflet map init error

### DIFF
--- a/src/components/home/LeafletMap.tsx
+++ b/src/components/home/LeafletMap.tsx
@@ -3,9 +3,10 @@
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function LeafletMap() {
+  const mapRef = useRef<L.Map | null>(null);
   const position: [number, number] = [42.85848, 74.61693];
 
   useEffect(() => {
@@ -19,8 +20,19 @@ export default function LeafletMap() {
     });
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (mapRef.current) {
+        mapRef.current.remove();
+      }
+    };
+  }, []);
+
   return (
     <MapContainer
+      whenCreated={(map) => {
+        mapRef.current = map;
+      }}
       center={position}
       zoom={16}
       scrollWheelZoom={false}


### PR DESCRIPTION
## Summary
- avoid duplicate Leaflet map initialization by cleaning up map instance

## Testing
- `npm run build` *(fails: Type error in src/app/admin/categories/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68594a6e18dc83229dce888f26a80297