### PR TITLE
Replace map with Stamen Toner Lite tiles

### DIFF
--- a/src/components/home/Map.tsx
+++ b/src/components/home/Map.tsx
@@ -30,8 +30,8 @@ export default function Map() {
         className="w-full h-full"
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>'
-          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+          attribution='Map tiles by <a href="https://stamen.com">Stamen Design</a>, <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
         />
         <Marker position={position}>
           <Popup>Кулатова 8/1, Бишкек</Popup>


### PR DESCRIPTION
## Summary
- switch the Leaflet TileLayer to use Stamen Toner Lite tiles

## Testing
- `npm run lint` *(fails: various eslint errors)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859565fc27883228b93f66df4905e53