### PR TITLE
Replace map with Stamen Toner Lite tiles

### DIFF
--- a/src/components/home/Map.tsx
+++ b/src/components/home/Map.tsx
@@ -6,9 +6,14 @@ import { useEffect } from "react";
 import "leaflet/dist/leaflet.css";
 
 const position: [number, number] = [42.8585, 74.6169];
+const mapId = "home-map";
 
 export default function Map() {
   useEffect(() => {
+    const container = L.DomUtil.get(mapId);
+    if (container) {
+      (container as any)._leaflet_id = null;
+    }
     // Fix default icon paths when using Leaflet with Next.js
     delete (L.Icon.Default.prototype as any)._getIconUrl;
     L.Icon.Default.mergeOptions({
@@ -24,14 +29,15 @@ export default function Map() {
   return (
     <div className="w-full h-full rounded-lg overflow-hidden shadow-lg">
       <MapContainer
+        id={mapId}
         center={position}
         zoom={18}
         scrollWheelZoom={false}
         className="w-full h-full"
       >
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>'
-          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+          attribution='Map tiles by <a href="https://stamen.com">Stamen Design</a>, <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
         />
         <Marker position={position}>
           <Popup>Кулатова 8/1, Бишкек</Popup>


### PR DESCRIPTION
## Summary
- switch the Leaflet TileLayer to use Stamen Toner Lite tiles
- ensure the map container is reset during hot reloads

## Testing
- `npm run lint` *(fails: ESLint errors in multiple files)*
- `npm run build` *(fails: type error in `src/app/admin/categories/page.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_6859565fc27883228b93f66df4905e53