### PR TITLE
Integrate Launch UI hero styling

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { signOut } from "next-auth/react";
 import React, { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+import Section from "@/components/launchui/Section";
+import Glow from "@/components/launchui/Glow";
 
 const Hero: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
@@ -31,15 +33,16 @@ const Hero: React.FC = () => {
   };
 
   return (
-    <section
+    <Section
       id="hero"
-      className="relative bg-background h-screen flex items-center justify-center text-foreground bg-cover bg-center"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden"
     >
-      <div className="relative flex flex-col items-center text-center px-6 z-10">
-        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold">
+      <Glow className="-z-10" variant="center" />
+      <div className="relative flex flex-col items-center text-center px-6 z-10 gap-6">
+        <h1 className="from-foreground to-muted-foreground bg-gradient-to-r bg-clip-text text-4xl font-bold text-transparent sm:text-5xl md:text-6xl">
           Система сервиса Best Electronics
         </h1>
-        <p className="mb-8 max-w-xl">
+        <p className="mb-8 max-w-xl text-muted-foreground">
           Мы предлагаем профессиональный ремонт и модернизацию электроники.
           Используйте кнопку ниже, чтобы отправить заявку.
         </p>
@@ -66,7 +69,7 @@ const Hero: React.FC = () => {
           )}
         </div>
       </div>
-    </section>
+    </Section>
   );
 };
 

--- a/src/components/launchui/Glow.tsx
+++ b/src/components/launchui/Glow.tsx
@@ -1,0 +1,46 @@
+import { cva, VariantProps } from "class-variance-authority";
+import React from "react";
+
+import { cn } from "@/lib/utils";
+
+const glowVariants = cva("absolute w-full", {
+  variants: {
+    variant: {
+      top: "top-0",
+      above: "-top-[128px]",
+      bottom: "bottom-0",
+      below: "-bottom-[128px]",
+      center: "top-[50%]",
+    },
+  },
+  defaultVariants: {
+    variant: "top",
+  },
+});
+
+export interface GlowProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof glowVariants> {}
+
+export default function Glow({ className, variant, ...props }: GlowProps) {
+  return (
+    <div
+      data-slot="glow"
+      className={cn(glowVariants({ variant }), className)}
+      {...props}
+    >
+      <div
+        className={cn(
+          "from-brand-foreground/50 to-transparent absolute left-1/2 h-[256px] w-[60%] -translate-x-1/2 scale-[2.5] rounded-[50%] bg-[radial-gradient(ellipse_at_center,var(--tw-gradient-stops))] opacity-20 sm:h-[512px] dark:opacity-100",
+          variant === "center" && "-translate-y-1/2",
+        )}
+      />
+      <div
+        className={cn(
+          "from-brand/30 to-transparent absolute left-1/2 h-[128px] w-[40%] -translate-x-1/2 scale-200 rounded-[50%] bg-[radial-gradient(ellipse_at_center,var(--tw-gradient-stops))] opacity-20 sm:h-[256px] dark:opacity-100",
+          variant === "center" && "-translate-y-1/2",
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/launchui/Section.tsx
+++ b/src/components/launchui/Section.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export default function Section({ className, ...props }: React.ComponentProps<"section">) {
+  return (
+    <section
+      data-slot="section"
+      className={cn("bg-background text-foreground px-4 py-12 sm:py-24 md:py-32", className)}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add Launch UI `Glow` and `Section` helpers
- restyle home hero with Launch UI look and gradient glow

## Testing
- `npm run lint` *(fails: multiple TypeScript and ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685992453b54832281caa8f9b95c527c