### PR TITLE
Update review carousel visuals

### DIFF
--- a/src/components/home/Reviews.tsx
+++ b/src/components/home/Reviews.tsx
@@ -50,7 +50,7 @@ const reviews: Review[] = [
 
 function ReviewCard({ review }: { review: Review }) {
   return (
-    <div className="bg-background rounded-lg shadow p-4 flex w-64 items-start gap-3 transform transition-transform hover:scale-105">
+    <div className="bg-background rounded-lg shadow p-4 flex w-80 items-start gap-3 transform transition-transform hover:scale-105">
       <Image
         src={review.avatar}
         alt={review.name}
@@ -75,14 +75,14 @@ export default function Reviews() {
       <BaseContainer>
         <h2 className="text-3xl font-bold text-center mb-6">Отзывы клиентов</h2>
         <div className="relative overflow-hidden rounded-lg group">
-          <div className="absolute inset-0 pointer-events-none before:absolute before:left-0 before:top-0 before:h-full before:w-12 before:bg-gradient-to-r before:from-background before:via-background/70 before:to-transparent before:rounded-l-lg after:absolute after:right-0 after:top-0 after:h-full after:w-12 after:bg-gradient-to-l after:from-background after:via-background/70 after:to-transparent after:rounded-r-lg" />
+        <div className="absolute inset-0 pointer-events-none before:absolute before:left-0 before:top-0 before:h-full before:w-16 before:bg-gradient-to-r before:from-background before:via-background/80 before:to-transparent before:rounded-l-lg after:absolute after:right-0 after:top-0 after:h-full after:w-16 after:bg-gradient-to-l after:from-background after:via-background/80 after:to-transparent after:rounded-r-lg" />
           <div className="space-y-4 py-4">
-            <div className="flex gap-4 whitespace-nowrap animate-marquee-right group-hover:[animation-play-state:paused]">
+            <div className="flex gap-4 whitespace-nowrap animate-marquee-right-slow group-hover:[animation-play-state:paused]">
               {doubled.map((review, idx) => (
                 <ReviewCard review={review} key={`top-${idx}`} />
               ))}
             </div>
-            <div className="flex gap-4 whitespace-nowrap animate-marquee-left group-hover:[animation-play-state:paused]">
+            <div className="flex gap-4 whitespace-nowrap animate-marquee-left-slow group-hover:[animation-play-state:paused]">
               {doubled.map((review, idx) => (
                 <ReviewCard review={review} key={`bottom-${idx}`} />
               ))}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -96,6 +96,14 @@ const config = {
           from: { transform: "translateX(0)" },
           to: { transform: "translateX(50%)" },
         },
+        "marquee-left-slow": {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(-50%)" },
+        },
+        "marquee-right-slow": {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(50%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -103,6 +111,8 @@ const config = {
         "menu-slide-down": "menu-slide-down 0.3s ease forwards",
         "marquee-left": "marquee-left 30s linear infinite",
         "marquee-right": "marquee-right 30s linear infinite",
+        "marquee-left-slow": "marquee-left 45s linear infinite",
+        "marquee-right-slow": "marquee-right 60s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- tweak animation speeds for review rows
- make edge fade overlays softer
- bump card width so text stays inside

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859a8d7e0908322b2af6b660673b947